### PR TITLE
Change path in redirect route to only match the url '/'

### DIFF
--- a/server.js
+++ b/server.js
@@ -28,7 +28,7 @@ app.use('/ouest_france',ouest_france);
 app.use('/pays_de_la_loire',pays_de_la_loire);
 app.use('/the_place_to_bio',the_place_to_bio);
 app.use('/we_demain',we_demain);
-app.use('/',function(req, res, next){
+app.use(/\/$/,function(req, res, next){
 	res.redirect('http://www.hyblab.fr/evenements/hyblab-datajournalisme/');
 });
 


### PR DESCRIPTION
Avoid redirecting missing files (.css, .js, etc.). Redirections result in loading the wrong files instead of triggering the more self-explanatory "not found" error.